### PR TITLE
Fix login form for Secure

### DIFF
--- a/app/rythm/Secure/login.html
+++ b/app/rythm/Secure/login.html
@@ -2,7 +2,7 @@
 @extends("_layout")
 <div id="login">
     <h1>@msg("secure.title")</h1>
-    <form action="@url(authenticate())">
+    <form action="@url(authenticate())" method="post">
     @authenticityToken()
 
     @if (flash.contains("error")) {


### PR DESCRIPTION
I fix the login form from the built-in Secure template. It sends GET-request, rather than the required POST-request. Before this login form is not working.
