### PR TITLE
Display 'getMoreHTML' messages nicely in 500 error template

### DIFF
--- a/app/rythm/e500.html
+++ b/app/rythm/e500.html
@@ -133,7 +133,7 @@
 	@{ String moreHtml = exception.getMoreHTML() }@
 	@if (null != moreHtml) {
 		<div id="specific" class="block">
-			@moreHtml
+                        @moreHtml.raw()
 		</div>
 	}
     <div id="more" class="block">


### PR DESCRIPTION
Right now if I use the Play evolution plugin, when I need to apply an evolution, the e500 template display me the evolution HTML message as text so I can't use it.

With this pull request, the 'getMoreHTML' message from Play exceptions are displayed in raw mode so the resulting HTML is displayed as it should be.
