### PR TITLE
Forward loadApplicationClass method in ApplicationClassLoader wrapper

### DIFF
--- a/src/com/greenlaw110/rythm/play/RythmPlugin.java
+++ b/src/com/greenlaw110/rythm/play/RythmPlugin.java
@@ -177,6 +177,9 @@ public class RythmPlugin extends PlayPlugin {
             return pcl().getResourceAsStream(name);
         }
 
+        public Class<?> loadApplicationClass(String name) {
+            return pcl().loadApplicationClass(name);
+        }
     };
     
     @Override


### PR DESCRIPTION
There are weird issues (class cast exceptions as some classes are loaded by two separate classloaders) in precompiled mode with the ApplicationClassLoader wrapper introduced in the last version. 

The loadApplicationClass forward make them go away.
