### PR TITLE
The "spaceless" tag

### DIFF
--- a/app/rythm/spaceless.html
+++ b/app/rythm/spaceless.html
@@ -1,0 +1,4 @@
+@__simple__
+@assign("result") {
+  @doBody()
+}@(((String)result).trim().replaceAll(">\\s+<", "><").raw())

--- a/documentation/manual/reference.textile
+++ b/documentation/manual/reference.textile
@@ -759,6 +759,23 @@ bc. @set(title:"Profile of " + user.login)
 
 Unlike "set":http://www.playframework.org/documentation/1.2.4/tags#set tag in Groovy template engine, Rythm @set@ tag does not accept tag body. You can use "section":#section tag to achieve the same result.
 
+h3. <a name="spaceless">spaceless</a>
+
+Analog of the "spaceless":https://docs.djangoproject.com/en/dev/ref/templates/builtins/#spaceless tag from Django. Removes whitespace (@\s@) characters between HTML tags, including tabs and newlines.
+
+Template:
+
+bc. @spaceless() {
+  <ul>
+    <li>First item</li>
+    <li>Second   item</li>
+  </ul>
+}
+
+Output:
+
+bc. <ul><li>First item</li><li>Second   item</li></ul>
+
 h3. <a name="tag">tag</a>
 
 Alias of <a href="#def"><code>@def()</code></a>


### PR DESCRIPTION
It is analog of the [spaceless](https://docs.djangoproject.com/en/dev/ref/templates/builtins/#spaceless) tag from Django.
It is handy to use this tag when makeup contains list of an items where css property `display` was setted to `inline-block` and items must be closely aligned, but you don't want to write ugly code. For example: http://jsfiddle.net/kZzRp/
